### PR TITLE
Fix: Mudei o tipo do campo operador tbl documentos

### DIFF
--- a/src/models/mutuario-lei.model.js
+++ b/src/models/mutuario-lei.model.js
@@ -63,7 +63,7 @@ const DocumentosLei = sequelize.define(
       type: DataTypes.TEXT,
     },
     operador: {
-      type: DataTypes.INTEGER,
+      type: DataTypes.STRING,
     },
     status: {
       type: DataTypes.TEXT,
@@ -221,7 +221,7 @@ DocumentosLei.hasOne(AuditoriaLei, { foreignKey: "doc_id" });
 // AuditoriaLei.sync({ force: true });
 
 // sequelize.sync();
-// DocumentosLei.sync({ force: true });
+DocumentosLei.sync({ alter: true });
 // ImoveisLei.sync({ alter: true });
 
 module.exports = {


### PR DESCRIPTION
O tipo do campo operador estava como int e foi modificado por Varchar por causa do token id.